### PR TITLE
bump example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ ENV VAULT_ADDR=
 COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder build/bin/spiffe-vault /usr/local/bin/spiffe-vault
 COPY --from=vault-binary bin/vault /usr/local/bin/vault
-COPY --from=gcr.io/projectsigstore/cosign:v1.9.0 /ko-app/cosign /usr/local/bin/cosign
 ENTRYPOINT [ "/usr/local/bin/spiffe-vault" ]

--- a/charts/spiffe-vault/templates/spiffe-vault.yaml
+++ b/charts/spiffe-vault/templates/spiffe-vault.yaml
@@ -29,6 +29,8 @@ spec:
           value: "1"
         - name: DOCKER_CERT_PATH
           value: /certs/client
+        - name: VAULT_ADDR
+          value: {{ .Values.vault.address }}
       {{- end }}
       resources:
         {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/spiffe-vault/templates/spiffe-vault.yaml
+++ b/charts/spiffe-vault/templates/spiffe-vault.yaml
@@ -33,8 +33,8 @@ spec:
       resources:
         {{- toYaml .Values.resources | nindent 12 }}
       volumeMounts:
-        - name: spire-agent-sockets
-          mountPath: /var/run/spire/sockets
+        - name: spiffe-workload-api
+          mountPath: /spiffe-workload-api
           readOnly: true
       {{- if .Values.docker.enabled }}
         - name: docker-certs
@@ -74,10 +74,10 @@ spec:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   volumes:
-    - name: spire-agent-sockets
-      hostPath:
-        path: /run/spire/agent-sockets
-        type: DirectoryOrCreate
+    - name: spiffe-workload-api
+      csi:
+        driver: "csi.spiffe.io"
+        readOnly: true
     {{- if .Values.docker.enabled }}
     - name: docker-graph-storage
       emptyDir: {}

--- a/charts/spiffe-vault/values.yaml
+++ b/charts/spiffe-vault/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+vault:
+  address: http://vault-internal.vault-system:8200
+
 image:
   repository: philipssoftware/spiffe-vault
   pullPolicy: IfNotPresent

--- a/cmd/spiffe-vault/cli/auth.go
+++ b/cmd/spiffe-vault/cli/auth.go
@@ -13,13 +13,20 @@ import (
 	"github.com/philips-labs/spiffe-vault/pkg/vault"
 )
 
+const (
+	defaultAudience   = "CI"
+	defaultAuthPath   = "jwt"
+	defaultSocketPath = "unix:///spiffe-workload-api/spire-agent.sock"
+)
+
 // Auth creates an instance of *ffcli.Command to authenticate with vault using Spiffe
 func Auth() *ffcli.Command {
 	var (
-		flagset  = flag.NewFlagSet("spiffe-vault version", flag.ExitOnError)
-		authPath = flagset.String("authPath", "jwt", "the authentication path in Vault (default: jwt)")
-		role     = flagset.String("role", "", "the role to authenticate with against Vault")
-		audience = flagset.String("audience", "CI", "the bound audience to verify in the claims")
+		flagset    = flag.NewFlagSet("spiffe-vault version", flag.ExitOnError)
+		socketPath = flagset.String("socketPath", defaultSocketPath, fmt.Sprintf("the unix socket path to the spire-agent (default: %s).", defaultSocketPath))
+		authPath   = flagset.String("authPath", defaultAuthPath, fmt.Sprintf("the authentication path in Vault (default: %s)", defaultAuthPath))
+		role       = flagset.String("role", "", "the role to authenticate with against Vault")
+		audience   = flagset.String("audience", defaultAudience, fmt.Sprintf("the bound audience to verify in the claims (default: %s)", defaultAudience))
 	)
 	return &ffcli.Command{
 		Name:    "auth",
@@ -33,10 +40,14 @@ func Auth() *ffcli.Command {
 				return fmt.Errorf("authPath flag required")
 			}
 
+			if *socketPath == "" {
+				return fmt.Errorf("socketPath flag required")
+			}
+
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			jwt, err := spiffe.FetchJWT(ctx, *audience)
+			jwt, err := spiffe.FetchJWT(ctx, *socketPath, *audience)
 			if err != nil {
 				return err
 			}

--- a/example/README.md
+++ b/example/README.md
@@ -32,7 +32,7 @@ helm repo update
 Now we will deploy the Helm charts to our Kubernetes cluster.
 
 ```bash
-helm -n my-spire install spire philips-labs/spire --create-namespace -f k8s/spire-values.yaml
+helm -n spire-system upgrade spire philips-labs/spire --version 0.6.3 --create-namespace --install -f k8s/spire-values.yaml
 helm -n my-traefik install traefik traefik/traefik --create-namespace -f k8s/traefik-values.yaml
 helm -n my-vault install vault hashicorp/vault --create-namespace -f k8s/vault-values.yaml
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -63,8 +63,9 @@ In `k8s/spiffe-vault.yaml` we defined we want to use the `philipssoftware/spiffe
 Let's build this custom build now and then deploy our workload to Kubernetes.
 
 ```bash
+# from the example folder
 docker build -t philipssoftware/spiffe-vault-cosign:latest spiffe-vault-cosign
-helm -n my-app install my-app ../charts/spiffe-vault --create-namespace -f k8s/spiffe-vault.yaml
+helm -n my-app upgrade my-app ../charts/spiffe-vault --create-namespace --install -f k8s/spiffe-vault.yaml
 ```
 
 ### play with spiffe-vault
@@ -136,17 +137,22 @@ The push refers to repository [docker.io/marcofranssen/busybox]
 cfd97936a580: Mounted from library/busybox
 latest: digest: sha256:febcf61cd6e1ac9628f6ac14fa40836d16f3c6ddef3b303ff0321606e55ddd0b size: 527
 $ eval "$(spiffe-vault auth -role local)"
-$ cosign sign -key hashivault://cosign marcofranssen/busybox:latest
-Pushing signature to: index.docker.io/marcofranssen/busybox:sha256-febcf61cd6e1ac9628f6ac14fa40836d16f3c6ddef3b303ff0321606e55ddd0b.sig
-$ cosign verify -key hashivault://cosign marcofranssen/busybox:latest
+$ cosign sign --key hashivault://cosign marcofranssen/busybox:latest
+WARNING: Image reference marcofranssen/busybox:latest uses a tag, not a digest, to identify the image to sign.
 
-Verification for marcofranssen/busybox:latest --
+This can lead you to sign a different image than the intended one. Please use a
+digest (example.com/ubuntu@sha256:abc123...) rather than tag
+(example.com/ubuntu:latest) for the input to cosign. The ability to refer to
+images by tag will be removed in a future release.
+Pushing signature to: index.docker.io/marcofranssen/busybox
+$ cosign verify --key hashivault://cosign marcofranssen/busybox:latest
+
+Verification for index.docker.io/marcofranssen/busybox:latest --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
-  - Any certificates were verified against the Fulcio roots.
 
-[{"critical":{"identity":{"docker-reference":"index.docker.io/marcofranssen/busybox"},"image":{"docker-manifest-digest":"sha256:febcf61cd6e1ac9628f6ac14fa40836d16f3c6ddef3b303ff0321606e55ddd0b"},"type":"cosign container image signature"},"optional":null}]
+[{"critical":{"identity":{"docker-reference":"index.docker.io/marcofranssen/busybox"},"image":{"docker-manifest-digest":"sha256:dacd1aa51e0b27c0e36c4981a7a8d9d8ec2c4a74bf125c0a44d0709497a522e9"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 [kubernetes]: https://kubernetes.io "Production-Grade Container Orchestration"

--- a/example/README.md
+++ b/example/README.md
@@ -29,11 +29,12 @@ helm repo update
 
 ### Install
 
-Now we will deploy the Helm charts to our Kubernetes cluster.
+Now we will deploy the Helm charts to our Kubernetes cluster. In case you run Rancher Desktop, Traefik will already be there and below script will check that for you.
 
 ```bash
 helm -n spire-system upgrade spire philips-labs/spire --version 0.6.3 --create-namespace --install -f k8s/spire-values.yaml
-helm -n my-traefik install traefik traefik/traefik --create-namespace -f k8s/traefik-values.yaml
+kubectl describe ingressclasses.networking.k8s.io traefik ||
+helm -n traefik-system upgrade traefik traefik/traefik --version 20.1.1 --create-namespace --install -f k8s/traefik-values.yaml
 helm -n my-vault install vault hashicorp/vault --create-namespace -f k8s/vault-values.yaml
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -78,7 +78,6 @@ The flow below will perform the following steps.
 $ kubectl exec -n my-app -i -t \
     $(kubectl -n my-app get pods -l app.kubernetes.io/name=spiffe-vault -o jsonpath="{.items[0].metadata.name}") \
     -c spiffe-vault -- sh
-$ export VAULT_ADDR=http://vault-internal.my-vault:8200
 $ eval "$(spiffe-vault auth -role local)"
 $ vault list transit/keys
 Keys

--- a/example/README.md
+++ b/example/README.md
@@ -35,12 +35,15 @@ Now we will deploy the Helm charts to our Kubernetes cluster. In case you run Ra
 helm -n spire-system upgrade spire philips-labs/spire --version 0.6.3 --create-namespace --install -f k8s/spire-values.yaml
 kubectl describe ingressclasses.networking.k8s.io traefik ||
 helm -n traefik-system upgrade traefik traefik/traefik --version 20.1.1 --create-namespace --install -f k8s/traefik-values.yaml
-helm -n my-vault install vault hashicorp/vault --create-namespace -f k8s/vault-values.yaml
+helm -n vault-system upgrade vault hashicorp/vault --version 0.22.1 --create-namespace --install -f k8s/vault-values.yaml
 ```
 
 ### Provision Vault
 
-> :warning: Add `vault.localhost` to your hosts file (`/etc/hosts`).
+> **Note**: Add `vault.localhost` to your hosts file (`/etc/hosts`).
+>
+> As we deployed vault in development mode you can navigate to `http://vault.localhost` and
+> login on the UI using the token `root` (You should never ever deploy vault in development mode to production environments).
 
 Once the core infrastructure is deployed we will have to provision the authentication method to [Vault][hashi-vault]. Terraform will also provision a transit engine which I use in the example below. Also note the Vault policy prevents you from doing any other operations then allowed by the policy. Doing so enables us to have finegrained access to different resources in Vault.
 
@@ -116,7 +119,6 @@ A practical usecase for using the transit engine is for example in combination w
 $ kubectl exec -n my-app -i -t \
     $(kubectl -n my-app get pods -l app.kubernetes.io/name=spiffe-vault -o jsonpath="{.items[0].metadata.name}") \
     -c spiffe-vault -- sh
-$ export VAULT_ADDR=http://vault-internal.my-vault:8200
 $ docker login
 Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.
 Username: marcofranssen

--- a/example/k8s/spire-values.yaml
+++ b/example/k8s/spire-values.yaml
@@ -1,35 +1,35 @@
 server:
+  config:
+    logLevel: debug
+    jwtIssuer: spire-oidc.spire-system
+
   dataStorage:
     enabled: false
 
+agent:
+  config:
+    logLevel: debug
+
 oidc:
   enabled: true
+  config:
+    logLevel: debug
+
+    domains:
+      - localhost
+      - oidc-spire.dev.localhost
+
+    acme:
+      tosAccepted: true
+      emailAddress: my-email@domain.tld
+      directoryUrl: https://acme-staging-v02.api.letsencrypt.org/directory
 
   service:
     type: ClusterIP
 
-  logLevel: DEBUG
-
   insecureScheme:
     enabled: true
-
-  acme:
-    tosAccepted: true
-    emailAddress: marco.franssen@philips.com
-    directoryUrl: https://acme-staging-v02.api.letsencrypt.org/directory
-
-  jwtIssuer: spire-oidc.my-spire
-
-  domains:
-    - localhost
-    - spire-oidc.my-spire
-    - spire-oidc.my-spire.svc.cluster.local
-    - oidc-spire.dev.localhost
 
 spire:
   clusterName: "dev-cluster"
   trustDomain: "dev.localhost"
-  agent:
-    logLevel: DEBUG
-  server:
-    logLevel: DEBUG

--- a/example/spiffe-vault-cosign/Dockerfile
+++ b/example/spiffe-vault-cosign/Dockerfile
@@ -1,9 +1,5 @@
-FROM gcr.io/projectsigstore/cosign:v1.13.1 as cosign-bin
-
-FROM docker:20.10.21-alpine3.16 as docker-bin
-
-FROM philipssoftware/spiffe-vault:v0.4.0
+FROM philipssoftware/spiffe-vault:v0.5.0
 LABEL maintainer="marco.franssen@philips.com"
 ENV DOCKER_CERT_PATH=/certs/client
-COPY --from=docker-bin /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
+COPY --from=docker:20.10.21-alpine3.16 /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=gcr.io/projectsigstore/cosign:v1.13.1 /ko-app/cosign /usr/local/bin/cosign

--- a/example/spiffe-vault-cosign/Dockerfile
+++ b/example/spiffe-vault-cosign/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/projectsigstore/cosign:v1.9.1 as cosign-bin
+FROM gcr.io/projectsigstore/cosign:v1.13.1 as cosign-bin
 
-FROM docker:20.10.8 as docker-bin
+FROM docker:20.10.21-alpine3.16 as docker-bin
 
-FROM philipssoftware/spiffe-vault:v0.2.0
+FROM philipssoftware/spiffe-vault:v0.4.0
 LABEL maintainer="marco.franssen@philips.com"
 ENV DOCKER_CERT_PATH=/certs/client
 COPY --from=docker-bin /usr/local/bin/docker /usr/local/bin/docker

--- a/example/vault/modules/jwt-auth/variables.tf
+++ b/example/vault/modules/jwt-auth/variables.tf
@@ -10,5 +10,5 @@ variable "roles" {
 variable "oidc_discovery_url" {
   type        = string
   description = "The discovery url of the oidc service"
-  default     = "http://spire-oidc.my-spire"
+  default     = "http://spire-oidc.spire-system"
 }

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -8,12 +8,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
-const (
-	socketPath = "unix:///var/run/spire/sockets/agent.sock"
-)
-
 // FetchJWT retrieves a JWT SVID upon successfull attestation
-func FetchJWT(ctx context.Context, audience string) (string, error) {
+func FetchJWT(ctx context.Context, socketPath, audience string) (string, error) {
 	clientOptions := workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath))
 
 	jwtSource, err := workloadapi.NewJWTSource(ctx, clientOptions)


### PR DESCRIPTION
- Add configurable socketPath for spire-agent
- Bump spiffe-vault chart to use spiffe csi driver
- Bump version of cosign and docker for spiffe-vault-cosign example
- Remove manual step in example
- Bump spire chart in example to 0.6.3
- Conditionally install traefik if not exists
- Bump example to install pinned version of vault
- Optimize spiffe-vault container and spiffe-vault-cosign example container
- Update spiffe-vault-cosign example instructions

Please note, we still need to make the release of `spiffe-vault:v0.5.0` after merging this PR.

To test locally first build the image referred to in the example `spiffe-vault-cosign` dockerfile from the root folder.

```shell
docker build -t philipssoftware/spiffe-vault:v0.5.0 .
```