### PR TITLE
fix goreleaser

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -117,7 +117,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist ${{ (!startsWith(github.ref, 'refs/tags/') && '--snapshot') || '' }}
+          args: release --clean ${{ (!startsWith(github.ref, 'refs/tags/') && '--snapshot') || '' }}
         env:
           LDFLAGS: ${{ steps.release-vars.outputs.ldflags }}
           GIT_HASH: ${{ steps.release-vars.outputs.git_hash }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ dockers:
       - "ghcr.io/philips-labs/{{ .ProjectName }}:{{ .FullCommit }}"
     build_flag_templates:
       - "--pull"
-      - "--label=com.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.description={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,6 +71,7 @@ signs:
     artifacts: checksum
     args:
       - sign-blob
+      - --yes
       - --key
       - cosign.key
       - '--output-certificate=${certificate}'
@@ -83,6 +84,7 @@ signs:
     artifacts: binary
     args:
       - sign-blob
+      - --yes
       - --key
       - cosign.key
       - '--output-certificate=${certificate}'
@@ -95,6 +97,7 @@ signs:
     artifacts: archive
     args:
       - sign-blob
+      - --yes
       - --key
       - cosign.key
       - '--output-certificate=${certificate}'
@@ -102,11 +105,13 @@ signs:
       - '${artifact}'
 
 docker_signs:
-  - cmd: cosign
-    artifacts: all
+  - artifacts: all
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
     output: true
     args:
       - 'sign'
+      - --yes
       - --key
       - cosign.key
       - '${artifact}'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,6 @@ builds:
 archives:
   - id: archive
     format: tar.gz
-    replacements:
-      darwin: macOS
     files:
       - LICENSE*
       - README*

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ image: ## build the binary in a docker image
 		.
 
 .PHONY: snapshot-release
-snapshot-release: ## creates a snapshot release using goreleaser
-	LDFLAGS=$(LDFLAGS) GIT_TAG=$(GIT_TAG) GIT_HASH=$(GIT_HASH) goreleaser release --snapshot --rm-dist
+snapshot-release: $(GO_PATH)/bin/goreleaser ## creates a snapshot release using goreleaser
+	LDFLAGS=$(LDFLAGS) GIT_TAG=$(GIT_TAG) GIT_HASH=$(GIT_HASH) goreleaser release --snapshot --clean
 
 .PHONY: release
-release: ## creates a release using goreleaser
+release: $(GO_PATH)/bin/goreleaser ## creates a release using goreleaser
 	LDFLAGS=$(LDFLAGS) GIT_TAG=$(GIT_TAG) GIT_HASH=$(GIT_HASH) goreleaser release
 
 release-vars: ## print the release variables for goreleaser
@@ -66,6 +66,9 @@ $(GO_PATH)/bin/goimports:
 
 $(GO_PATH)/bin/golint:
 	go install golang.org/x/lint/golint@latest
+
+$(GO_PATH)/bin/goreleaser:
+	go install github.com/goreleaser/goreleaser@latest
 
 .PHONY: lint
 lint: $(GO_PATH)/bin/goimports $(GO_PATH)/bin/golint ## runs linting


### PR DESCRIPTION
- Replace deprecated --rm-dist flag with --clean
- Auto install goreleaser when binary is missing
- Remove deprecated replacements config from archives
- Fix cosign in goreleaser
- Fix opencontainers.image.created label
