### PR TITLE
Bump runners and fix Go caching

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -18,7 +18,7 @@ jobs:
         target: [vault]
 
     name: Check module ${{ matrix.target }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     name: Continuous Integration
 
@@ -66,7 +66,7 @@ jobs:
   release:
     name: release
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     outputs:
       container_digest: ${{ steps.container_info.outputs.container_digest }}
@@ -145,7 +145,7 @@ jobs:
 
   provenance:
     name: Generate provenance
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [release]
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -188,7 +188,7 @@ jobs:
     name: container-provenance
     needs: [release]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -26,15 +26,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Cache Go modules
-        uses: actions/cache@v3.3.1
-        id: go-mod-cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Get dependencies
         run: go mod download
 

--- a/example/vault/environments/local/versions.tf
+++ b/example/vault/environments/local/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "~> 3.20.0"
     }
   }


### PR DESCRIPTION
- Bump runners from ubuntu-20.04 to ubuntu-22.04
- Remove caching action as this is integrated in setup-go
